### PR TITLE
Added code to prevent session expiry in Keygen teardown

### DIFF
--- a/src/main/java/com/fortanix/sdkms/performance/sampler/AbstractSDKMSSamplerClient.java
+++ b/src/main/java/com/fortanix/sdkms/performance/sampler/AbstractSDKMSSamplerClient.java
@@ -31,7 +31,7 @@ public abstract class AbstractSDKMSSamplerClient extends AbstractJavaSamplerClie
     ApiClient apiClient;
     private AuthenticationApi authenticationApi;
 
-    private void login() {
+    public void login() {
         AuthResponse authResponse = null;
         try {
             authResponse = this.authenticationApi.authorize();


### PR DESCRIPTION
Made changes to AbstractSDKMSSamplerClient and KeyGenerationSampler for a temporary fix - will be making a permanent fix after considering all implications.