### PR TITLE
Added test cases for batch encryption/decryption as per ticket ROQA-9

### DIFF
--- a/src/main/java/com/fortanix/sdkms/performance/sampler/AbstractEncryptionAndDecryptionSampler.java
+++ b/src/main/java/com/fortanix/sdkms/performance/sampler/AbstractEncryptionAndDecryptionSampler.java
@@ -31,10 +31,13 @@ import static com.fortanix.sdkms.performance.sampler.Constants.*;
 public abstract class AbstractEncryptionAndDecryptionSampler extends AbstractSDKMSSamplerClient {
 
     String keyId;
-    EncryptRequestEx encryptRequest;
+    EncryptRequest encryptRequest;
+    EncryptRequestEx encryptRequestEx;
     EncryptionAndDecryptionApi encryptionAndDecryptionApi;
     EncryptionDecryptionHelper encryptionDecryptionHelper;
     private SecurityObjectsApi securityObjectsApi;
+    BatchEncryptRequestInner batchEncryptRequestInners;
+    BatchEncryptRequest batchEncryptRequest;
 
     @Override
     public void setupTest(JavaSamplerContext context) {
@@ -42,6 +45,7 @@ public abstract class AbstractEncryptionAndDecryptionSampler extends AbstractSDK
         int keySize = context.getIntParameter(KEY_SIZE, 1024);
         String mode = context.getParameter(MODE, "CBC");
         String filePath = context.getParameter(FILE_PATH);
+        int batchSize = context.getIntParameter(BATCH_SIZE, 0);
         ObjectType objectType = ObjectType.fromValue(algorithm);
         String input = "random-text";
         if(CryptMode.fromValue(mode) == CryptMode.FPE) {
@@ -71,7 +75,15 @@ public abstract class AbstractEncryptionAndDecryptionSampler extends AbstractSDK
             throw new ProviderException(e.getMessage());
         }
         this.encryptionDecryptionHelper = EncryptionDecryptionFactory.getHelper(EncryptionDecryptionType.valueOf(algorithm), CryptMode.fromValue(mode));
-        this.encryptRequest = this.encryptionDecryptionHelper.createEncryptRequest(new SobjectDescriptor().kid(this.keyId), input);
+        this.encryptRequestEx = this.encryptionDecryptionHelper.createEncryptRequest(new SobjectDescriptor().kid(this.keyId), input);
+
+        if (batchSize != 0){
+            this.batchEncryptRequest = new BatchEncryptRequest();
+            for ( int i = 0; i < batchSize ; i++ ) {
+                this.batchEncryptRequest.add(this.batchEncryptRequestInners);
+            }
+        }
+
         this.encryptionAndDecryptionApi = new EncryptionAndDecryptionApi(this.apiClient);
     }
 

--- a/src/main/java/com/fortanix/sdkms/performance/sampler/SignatureGenerationSampler.java
+++ b/src/main/java/com/fortanix/sdkms/performance/sampler/SignatureGenerationSampler.java
@@ -20,6 +20,7 @@ public class SignatureGenerationSampler extends AbstractSignatureSampler {
     @Override
     public SampleResult runTest(JavaSamplerContext context) {
         SampleResult result = new SampleResult();
+        this.apiClient.setDebugging(true);
         result.sampleStart();
         try {
             retryOperationIfSessionExpires(new RetryableOperation() {


### PR DESCRIPTION
The batchRequestInner class does not make any sense and is still pointing to the normal encrypt API instead of the batch Encrypt API.

*** NOTE: THIS PR IS A WORK IN PROGRESS. PLEASE DO NOT MERGE ***