### PR TITLE
Added fixes for ROQA-36 and ROQA-37

### DIFF
--- a/src/main/java/com/fortanix/sdkms/performance/helper/AESHelper.java
+++ b/src/main/java/com/fortanix/sdkms/performance/helper/AESHelper.java
@@ -52,10 +52,6 @@ public class AESHelper extends EncryptionDecryptionHelper {
 
     @Override
     public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag, byte[] iv) {
-        DecryptRequestEx decryptRequest = new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).ad(this.ad).tag(tag).iv(iv);
-        if(mode != CryptMode.FPE) {
-            decryptRequest.iv(this.iv);
-        }
-        return decryptRequest;
+        return new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).ad(this.ad).tag(tag).iv(iv);
     }
 }

--- a/src/main/java/com/fortanix/sdkms/performance/helper/AESHelper.java
+++ b/src/main/java/com/fortanix/sdkms/performance/helper/AESHelper.java
@@ -51,19 +51,21 @@ public class AESHelper extends EncryptionDecryptionHelper {
     }
 
     @Override
-    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher) {
+    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag) {
         // generate tag
-        byte[] tag = null;
-        if (mode == CryptMode.GCM || mode == CryptMode.CCM) {
-            int tagLengthInByte = AES_BLOCK_SIZE;
-            tag = new byte[tagLengthInByte];
-            byte[] temp = new byte[cipher.length - tagLengthInByte];
-            // separate out GCM tag
-            System.arraycopy(cipher, 0, tag, 0, tagLengthInByte);
-            // separate out cipher text
-            System.arraycopy(cipher, tagLengthInByte, temp, 0, temp.length);
-            cipher = temp;
-        }
+//        byte[] tag = null;
+//        if (mode == CryptMode.GCM || mode == CryptMode.CCM) {
+//            int tagLengthInByte = AES_BLOCK_SIZE;
+//            tag = new byte[tagLengthInByte];
+//            byte[] temp = new byte[cipher.length - tagLengthInByte];
+//            // separate out GCM tag
+//            System.arraycopy(cipher, 0, tag, 0, tagLengthInByte);
+//            // separate out cipher text
+//            System.arraycopy(cipher, tagLengthInByte, temp, 0, temp.length);
+//            cipher = temp;
+//        }
+
+        // Getting the Tag value from the Encrypt request
         DecryptRequestEx decryptRequest = new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).ad(this.ad).tag(tag);
         if(mode != CryptMode.FPE) {
             decryptRequest.iv(this.iv);

--- a/src/main/java/com/fortanix/sdkms/performance/helper/AESHelper.java
+++ b/src/main/java/com/fortanix/sdkms/performance/helper/AESHelper.java
@@ -51,22 +51,8 @@ public class AESHelper extends EncryptionDecryptionHelper {
     }
 
     @Override
-    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag) {
-        // generate tag
-//        byte[] tag = null;
-//        if (mode == CryptMode.GCM || mode == CryptMode.CCM) {
-//            int tagLengthInByte = AES_BLOCK_SIZE;
-//            tag = new byte[tagLengthInByte];
-//            byte[] temp = new byte[cipher.length - tagLengthInByte];
-//            // separate out GCM tag
-//            System.arraycopy(cipher, 0, tag, 0, tagLengthInByte);
-//            // separate out cipher text
-//            System.arraycopy(cipher, tagLengthInByte, temp, 0, temp.length);
-//            cipher = temp;
-//        }
-
-        // Getting the Tag value from the Encrypt request
-        DecryptRequestEx decryptRequest = new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).ad(this.ad).tag(tag);
+    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag, byte[] iv) {
+        DecryptRequestEx decryptRequest = new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).ad(this.ad).tag(tag).iv(iv);
         if(mode != CryptMode.FPE) {
             decryptRequest.iv(this.iv);
         }

--- a/src/main/java/com/fortanix/sdkms/performance/helper/EncryptionDecryptionHelper.java
+++ b/src/main/java/com/fortanix/sdkms/performance/helper/EncryptionDecryptionHelper.java
@@ -29,7 +29,7 @@ public class EncryptionDecryptionHelper {
         return new EncryptRequestEx().key(key).alg(this.algorithm).plain(plainText.getBytes()).mode(this.mode).iv(this.iv).ad(this.ad).tagLen(this.tagLen);
     }
 
-    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag) {
-        return new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).iv(this.iv).ad(this.ad).tag(tag);
+    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag, byte[] iv) {
+        return new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).ad(this.ad).tag(tag).iv(iv);
     }
 }

--- a/src/main/java/com/fortanix/sdkms/performance/helper/EncryptionDecryptionHelper.java
+++ b/src/main/java/com/fortanix/sdkms/performance/helper/EncryptionDecryptionHelper.java
@@ -29,7 +29,7 @@ public class EncryptionDecryptionHelper {
         return new EncryptRequestEx().key(key).alg(this.algorithm).plain(plainText.getBytes()).mode(this.mode).iv(this.iv).ad(this.ad).tagLen(this.tagLen);
     }
 
-    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher) {
-        return new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).iv(this.iv).ad(this.ad);
+    public DecryptRequestEx createDecryptRequest(SobjectDescriptor key, byte[] cipher, byte[] tag) {
+        return new DecryptRequestEx().key(key).alg(this.algorithm).cipher(cipher).mode(this.mode).iv(this.iv).ad(this.ad).tag(tag);
     }
 }

--- a/src/main/java/com/fortanix/sdkms/performance/sampler/DecryptionSampler.java
+++ b/src/main/java/com/fortanix/sdkms/performance/sampler/DecryptionSampler.java
@@ -27,14 +27,16 @@ public class DecryptionSampler extends AbstractEncryptionAndDecryptionSampler {
         super.setupTest(context);
         byte[] cipher;
         byte[] tag;
+        byte[] iv;
         try {
             cipher = this.encryptionAndDecryptionApi.encryptEx(this.encryptRequest).getCipher();
             tag = this.encryptionAndDecryptionApi.encryptEx(this.encryptRequest).getTag();
+            iv = this.encryptionAndDecryptionApi.encryptEx(this.encryptRequest).getIv();
         } catch (ApiException e) {
             LOGGER.log(Level.INFO, "failure in encrypting : " + e.getMessage(), e);
             throw new ProviderException(e.getMessage());
         }
-        this.decryptRequest = this.encryptionDecryptionHelper.createDecryptRequest(new SobjectDescriptor().kid(this.keyId), cipher, tag);
+        this.decryptRequest = this.encryptionDecryptionHelper.createDecryptRequest(new SobjectDescriptor().kid(this.keyId), cipher, tag, iv);
     }
 
     @Override

--- a/src/main/java/com/fortanix/sdkms/performance/sampler/DecryptionSampler.java
+++ b/src/main/java/com/fortanix/sdkms/performance/sampler/DecryptionSampler.java
@@ -26,13 +26,15 @@ public class DecryptionSampler extends AbstractEncryptionAndDecryptionSampler {
     public void setupTest(JavaSamplerContext context) {
         super.setupTest(context);
         byte[] cipher;
+        byte[] tag;
         try {
             cipher = this.encryptionAndDecryptionApi.encryptEx(this.encryptRequest).getCipher();
+            tag = this.encryptionAndDecryptionApi.encryptEx(this.encryptRequest).getTag();
         } catch (ApiException e) {
             LOGGER.log(Level.INFO, "failure in encrypting : " + e.getMessage(), e);
             throw new ProviderException(e.getMessage());
         }
-        this.decryptRequest = this.encryptionDecryptionHelper.createDecryptRequest(new SobjectDescriptor().kid(this.keyId), cipher);
+        this.decryptRequest = this.encryptionDecryptionHelper.createDecryptRequest(new SobjectDescriptor().kid(this.keyId), cipher, tag);
     }
 
     @Override

--- a/test-bench.sh
+++ b/test-bench.sh
@@ -490,7 +490,7 @@ function mac_verify_task() {
     OPERATION=MAC_VERIFY
     validate
     get_input ${@:1}
-    update_jmx "/src/test/jmeter/mac-sign-verify-template.jmx" "/target/jmx/"$FILE_NAME".jmx"
+    update_jmx "/src/test/jmeter/mac-verify-template.jmx" "/target/jmx/"$FILE_NAME".jmx"
     print_start
     mvn verify -Djmx.path="target/jmx" $JVM_ARGS
     print_end $FILE_NAME $OPERATION


### PR DESCRIPTION
Passing the value of Tag from the Encrypt Request seemed to solve the problem of CCM and GCM Decrypt requests from erroring out. Corrected the template name for MacVerify JMX template.