### PR TITLE
Add mode to operation name if specified as arguments to keyoperation …

### DIFF
--- a/test-bench.sh
+++ b/test-bench.sh
@@ -186,11 +186,16 @@ function print_end(){
 
     HTML_OUTPUT_DIR=$(ls -td -- $SDKMS_REST_API_HOME"/target/jmeter/reports/"* | head -n 1)
     CSV_OUTPUT_FILE=$(ls -td -- $SDKMS_REST_API_HOME"/target/jmeter/results/"* | head -n 1)
+    FILE_IDF_SUB="$FILE_IDF"
+    if [ ! -z "$MODE" ]
+    then
+        FILE_IDF_SUB="$MODE"
+    fi
     if [ -z "$BATCH_SIZE" ]
     then
-        AGGREGATE_OUTPUT_FILE=$SDKMS_REST_API_HOME"/target/jmeter/results/"$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-"$FILE_IDF"-AGGREGATE.csv"
+        AGGREGATE_OUTPUT_FILE=$SDKMS_REST_API_HOME"/target/jmeter/results/"$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-"$FILE_IDF_SUB"-AGGREGATE.csv"
     else
-        AGGREGATE_OUTPUT_FILE=$SDKMS_REST_API_HOME"/target/jmeter/results/"BATCH""$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-BATCHSIZE-"$BATCH_SIZE"-"$FILE_IDF"-AGGREGATE.csv"
+        AGGREGATE_OUTPUT_FILE=$SDKMS_REST_API_HOME"/target/jmeter/results/"BATCH""$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-BATCHSIZE-"$BATCH_SIZE"-"$FILE_IDF_SUB"-AGGREGATE.csv"
     fi
     java -jar $SDKMS_REST_API_HOME"/target/jmeter/lib/ext/cmdrunner-2.0.jar" --tool Reporter --generate-csv $AGGREGATE_OUTPUT_FILE --input-jtl $CSV_OUTPUT_FILE --plugin-type AggregateReport
 
@@ -209,8 +214,8 @@ function print_end(){
 
     awk -v THREADS="$THREAD_COUNT" -v CAPACITY="$BANDWIDTH" -v TIME="$EXECUTION_TIME" -v OP_NAME="$OP_NAME" 'BEGIN { FS=","; OFS="," }; FNR == 1 { print "operation","threads","duration(sec)","total operations","average latency(ms)","p90 latency(ms)","p99 latency(ms)","min latency (ms)","max latency (ms)","Error %","Throughput per sec","Cipher capacity (kb/s)" }; FNR  ==2 { print OP_NAME,THREADS,TIME,$2,$3,$5,$7,$8,$9,$10,$11,CAPACITY }' $AGGREGATE_OUTPUT_FILE > temp.csv && mv temp.csv $AGGREGATE_OUTPUT_FILE;
 
-    mv $HTML_OUTPUT_DIR $SDKMS_REST_API_HOME"/target/jmeter/reports/"$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-"$FILE_IDF"-HTML"
-    mv $CSV_OUTPUT_FILE $SDKMS_REST_API_HOME"/target/jmeter/results/"$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-"$FILE_IDF"-DATA.csv"
+    mv $HTML_OUTPUT_DIR $SDKMS_REST_API_HOME"/target/jmeter/reports/"$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-"$FILE_IDF_SUB"-HTML"
+    mv $CSV_OUTPUT_FILE $SDKMS_REST_API_HOME"/target/jmeter/results/"$2"-"$ALGORITHM"-"$KEYSIZE"-"$THREAD_COUNT"THREADS-"$EXECUTION_TIME"SECONDS-"$FILE_IDF_SUB"-DATA.csv"
     info "Html output can be found at "$HTML_OUTPUT_DIR"/index.html"
     info "csv output can be found at "$AGGREGATE_OUTPUT_FILE
 }


### PR DESCRIPTION
The PTB code does not add the mode(if present) as tag to the csv file and the operation name. Hence it is quite difficult to identify the operation name from the csv file(eg AES(GCM) and AES(CBC). This changes attaches mode tag to the AGGREGATE file